### PR TITLE
update arm64 cross compiling

### DIFF
--- a/.github/workflows/build-microarch.yml
+++ b/.github/workflows/build-microarch.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             arch: arm64
             cc: aarch64-linux-gnu-gcc
-            pkg: "libsodium-dev gcc-aarch64-linux-gnu"
+            pkg: "libsodium-dev:arm64 gcc-aarch64-linux-gnu"
             strip: aarch64-linux-gnu-strip
             exe: ''
             cflags: "-march=armv8-a"
@@ -31,6 +31,7 @@ jobs:
             arch: x64
             msystem: MINGW64
             cc: gcc
+            packages: "mingw-w64-x86_64-toolchain mingw-w64-x86_64-libsodium"
             strip: strip
             exe: '.exe'
             cflags: "-march=znver3 -mtune=znver3"
@@ -38,6 +39,7 @@ jobs:
             arch: arm64
             msystem: CLANGARM64
             cc: clang
+            packages: "clangarm64-toolchain clangarm64-libsodium"
             strip: strip
             exe: '.exe'
             cflags: "-march=armv8-a"
@@ -72,8 +74,7 @@ jobs:
           update: true
           install: >-
             base-devel
-            mingw-w64-${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}-toolchain
-            mingw-w64-${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}-libsodium
+            ${{ matrix.packages }}
             autoconf
             automake
 
@@ -82,6 +83,9 @@ jobs:
         run: |
           brew update
           brew install automake autoconf libsodium pkg-config
+          echo "CPPFLAGS=-I$(brew --prefix libsodium)/include" >> $GITHUB_ENV
+          echo "LDFLAGS=-L$(brew --prefix libsodium)/lib" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Build (Windows)
         if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ run `./configure --help` to see all available options.
 
 Finally, `make` to start building (`gmake` in \*BSD platforms).
 
+### Cross-compiling for ARM64
+
+To build for ARM64 on an x86 host you need a cross compiler and the ARM64
+version of libsodium installed. On Debian or Ubuntu systems this can be done
+with:
+
+```bash
+sudo dpkg --add-architecture arm64
+sudo apt update
+sudo apt install gcc-aarch64-linux-gnu libsodium-dev:arm64
+```
+
+If `libsodium-dev:arm64` is not available from your package mirror, compile
+libsodium for ARM64 manually and ensure `aarch64-linux-gnu-gcc` can find the
+resulting library when linking.
+
 ### Usage
 
 mkp224o needs one or more filters to work.


### PR DESCRIPTION
## Summary
- add README section about cross-compiling for arm64
- install libsodium for arm64 in Linux build
- set macOS build flags so libsodium is found
- fix package names for windows arm64 build

## Testing
- `./configure`
- `make`
- `make test_base64 test_base32 test_base16 test_ed25519`
- `./test_base64 && ./test_base32 && ./test_base16 && ./test_ed25519`

------
https://chatgpt.com/codex/tasks/task_e_6876176261a083329725e05b051de692