### PR TITLE
Fix Windows ARM toolchain install

### DIFF
--- a/.github/workflows/build-microarch.yml
+++ b/.github/workflows/build-microarch.yml
@@ -39,7 +39,7 @@ jobs:
             arch: arm64
             msystem: CLANGARM64
             cc: clang
-            packages: "clangarm64-toolchain clangarm64-libsodium"
+            packages: ""
             strip: strip
             exe: '.exe'
             cflags: "-march=armv8-a"
@@ -77,6 +77,15 @@ jobs:
             ${{ matrix.packages }}
             autoconf
             automake
+
+      - name: Install Arm GNU Toolchain
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          $toolchain = "arm-gnu-toolchain.exe"
+          Invoke-WebRequest -Uri "https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-mingw-w64-x86_64-aarch64-none-elf.exe" -OutFile $toolchain
+          Start-Process -FilePath $toolchain -ArgumentList '/S','/D=C:\arm-gnu-toolchain' -Wait
+          "C:\arm-gnu-toolchain\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Summary
- install Arm GNU Toolchain when building on `windows-11-arm`
- avoid installing nonexistent `clangarm64-*` packages

## Testing
- `autoconf --version`
- `./configure`
- `make` *(fails: `sodium/core.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6877738fcb288332b1de4381e2b7d0b3